### PR TITLE
Fix issue with required argument on draft save

### DIFF
--- a/inc/MlphpDriver.php
+++ b/inc/MlphpDriver.php
@@ -98,7 +98,7 @@ final class MlphpDriver implements Driver
         return new BulkResult($count, $errors);
     }
 
-    private function createDocument($blogId, $post, $postMeta)
+    private function createDocument($blogId, $post, $postMeta=null)
     {
         return new Document($this->client, sprintf('/%s.xml', apply_filters(
             'ml_wpsearch_document_uri',


### PR DESCRIPTION
Saving a draft throws an error over a missing argument for document metadata. The metadata is optional and the function signature has been updated with a default null value if it isn't provided.