### PR TITLE
Updates to postmeta / term assignments not syncing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+  "name": "marklogic-marketing/WP-MarkLogic-Search",
+  "description": "Use MarkLogic for search on WordPress website.",
+  "homepage": "https://github.com/marklogic-marketing/WP-MarkLogic-Search",
+  "keywords": [
+    "wordpress","marklogic","search"
+  ],
+  "type": "wordpress-plugin"
+}

--- a/inc/MlphpDriver.php
+++ b/inc/MlphpDriver.php
@@ -98,8 +98,9 @@ final class MlphpDriver implements Driver
         return new BulkResult($count, $errors);
     }
 
-    private function createDocument($blogId, $post, $postMeta)
+    private function createDocument($blogId, $post, $postMeta = null)
     {
+
         return new Document($this->client, sprintf('/%s.xml', apply_filters(
             'ml_wpsearch_document_uri',
             $this->createURIwithPostID($blogId, $post),


### PR DESCRIPTION
Addresses #5 

This adds new actions to the SyncManager to account for syncing posts when postmeta is updated or when term assignments on a post are changed. This also moves the syncing of posts to the "shutdown" hook, and all the actions listening for updates to posts now just add the Post ID to an in-memory cache ($scheduledPosts), and on shutdown, that list of posts is de-duped, then each post in the list is synced.

By moving the actual sync to shutdown, this allows for various modifications to a post to happen in the same thread, but only sync the data to marklogic once.

For example, if I had code such as:

```
$post_id = wp_insert_post( [ 'post_title' => 'New Post', 'post_type' => 'post', 'post_status' => 'publish' ] );
update_post_meta( $post_id, 'some_key', 'some_value' );
```

The data stored in "some_key" would never be indexed to MarkLogic.

We could implement a simple listener on the "updated_post_meta" hook to sync the post whenever post_meta is updated, but that could potentially cause a MarkLogic sync request many times in a single thread, so deferring it to Sync once on shutdown reduces the number of remote requests needed to sync data from WordPress to MarkLogic but also accounts for the associated data being synced.